### PR TITLE
Fix terminal resize duplicate lines bug

### DIFF
--- a/.pickyignore
+++ b/.pickyignore
@@ -1,9 +1,13 @@
 .claude
 .git
+.gitignore
 .idea
 .pickignore
+.pickyignore
 cmd/picky/.claude
 go.mod
 go.sum
 picky
 picky-bin
+picky-darwin-arm64
+selected.txt

--- a/internal/app/app_token_integration_test.go
+++ b/internal/app/app_token_integration_test.go
@@ -57,6 +57,9 @@ func TestAppTokenIntegration(t *testing.T) {
 		model := tui.NewModel(tree, &ignores)
 		model.SetTokens(tokensMap)
 		
+		// Initialize the model to set up viewport
+		model.Init()
+		
 		// The model should now have the token map
 		// We can't directly access it, but we can verify through the view
 		view := model.View()

--- a/internal/tui/model_render_test.go
+++ b/internal/tui/model_render_test.go
@@ -49,6 +49,9 @@ func TestRenderDirectoryWithAllChildrenSelected(t *testing.T) {
 	
 	model.state = state
 	
+	// Initialize the model to set up viewport
+	model.Init()
+	
 	// Render and check
 	view := model.View()
 	lines := strings.Split(view, "\n")
@@ -116,6 +119,9 @@ func TestRenderAfterParentSelection(t *testing.T) {
 	
 	model.state = state
 	
+	// Initialize the model to set up viewport
+	model.Init()
+	
 	// Render and check
 	view := model.View()
 	lines := strings.Split(view, "\n")
@@ -171,6 +177,9 @@ func TestRenderPartialSelection(t *testing.T) {
 	state = state.SetSelected("/root/dir1/file1.txt", true)
 	
 	model.state = state
+	
+	// Initialize the model to set up viewport
+	model.Init()
 	
 	// Render and check
 	view := model.View()
@@ -229,6 +238,9 @@ func TestPromptModeDimmedTree(t *testing.T) {
 	state := domain.NewViewState(root.Path)
 	state = state.SetOpen("/root", true)
 	model.state = state
+	
+	// Initialize the model to set up viewport
+	model.Init()
 	
 	// Get initial view (not in prompt mode)
 	view := model.View()

--- a/internal/tui/model_resize_test.go
+++ b/internal/tui/model_resize_test.go
@@ -1,0 +1,149 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/eliooooooot/picky/internal/domain"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestResizeNoDuplicates(t *testing.T) {
+	// Build a deep tree structure
+	root := &domain.Node{
+		Path:  "/root",
+		Name:  "root",
+		IsDir: true,
+	}
+	
+	dir1 := &domain.Node{
+		Path:   "/root/dir1",
+		Name:   "dir1",
+		IsDir:  true,
+		Parent: root,
+	}
+	
+	dir2 := &domain.Node{
+		Path:   "/root/dir1/dir2",
+		Name:   "dir2",
+		IsDir:  true,
+		Parent: dir1,
+	}
+	
+	file1 := &domain.Node{
+		Path:   "/root/dir1/file1.txt",
+		Name:   "file1.txt",
+		IsDir:  false,
+		Parent: dir1,
+	}
+	
+	file2 := &domain.Node{
+		Path:   "/root/dir1/dir2/file2.txt",
+		Name:   "file2.txt",
+		IsDir:  false,
+		Parent: dir2,
+	}
+	
+	file3 := &domain.Node{
+		Path:   "/root/dir1/dir2/file3.txt",
+		Name:   "file3.txt",
+		IsDir:  false,
+		Parent: dir2,
+	}
+	
+	// Build tree structure
+	root.Children = []*domain.Node{dir1}
+	dir1.Children = []*domain.Node{dir2, file1}
+	dir2.Children = []*domain.Node{file2, file3}
+	
+	tree := &domain.Tree{Root: root}
+	ignores := make(map[string]struct{})
+	
+	// Create model and initialize
+	model := NewModel(tree, &ignores)
+	model.Init()
+	
+	// Open all directories
+	model.state = model.state.SetOpen(dir1.Path, true)
+	model.state = model.state.SetOpen(dir2.Path, true)
+	
+	// Simulate window size changes
+	m, _ := model.Update(tea.WindowSizeMsg{Width: 120, Height: 30})
+	model = m.(*Model)
+	m, _ = model.Update(tea.WindowSizeMsg{Width: 120, Height: 10}) // Shrink
+	model = m.(*Model)
+	m, _ = model.Update(tea.WindowSizeMsg{Width: 120, Height: 30}) // Grow back
+	model = m.(*Model)
+	
+	// Check for duplicates in the rendered output
+	view := model.View()
+	lines := strings.Split(view, "\n")
+	
+	// Count occurrences of each line
+	seen := make(map[string]int)
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed != "" {
+			seen[trimmed]++
+		}
+	}
+	
+	// Check for duplicates
+	for line, count := range seen {
+		// Skip header lines and empty lines
+		if strings.Contains(line, "Picky - File Selector") ||
+			strings.Contains(line, "navigate") ||
+			strings.Contains(line, "esc:") ||
+			line == "" {
+			continue
+		}
+		
+		if count > 1 {
+			t.Errorf("Line appears %d times (expected 1): %q", count, line)
+		}
+	}
+}
+
+func TestResizeMaintainsCursorVisibility(t *testing.T) {
+	// Build a tree with many items
+	root := &domain.Node{
+		Path:  "/root",
+		Name:  "root",
+		IsDir: true,
+	}
+	
+	// Create many files to exceed viewport
+	for i := 0; i < 50; i++ {
+		file := &domain.Node{
+			Path:   "/root/file" + string(rune('0'+i)) + ".txt",
+			Name:   "file" + string(rune('0'+i)) + ".txt",
+			IsDir:  false,
+			Parent: root,
+		}
+		root.Children = append(root.Children, file)
+	}
+	
+	tree := &domain.Tree{Root: root}
+	ignores := make(map[string]struct{})
+	
+	// Create model
+	model := NewModel(tree, &ignores)
+	model.Init()
+	
+	// Navigate to middle of list
+	for i := 0; i < 25; i++ {
+		model.state = domain.NavigateDown(model.tree.Root, model.state)
+	}
+	
+	// Resize window
+	m, _ := model.Update(tea.WindowSizeMsg{Width: 120, Height: 20})
+	model = m.(*Model)
+	m, _ = model.Update(tea.WindowSizeMsg{Width: 120, Height: 10}) // Smaller
+	model = m.(*Model)
+	
+	// Check that cursor is still visible in the view
+	view := model.View()
+	if !strings.Contains(view, "→") && !strings.Contains(view, "▶") {
+		t.Error("Cursor indicator not found in view after resize")
+	}
+}

--- a/internal/tui/model_token_test.go
+++ b/internal/tui/model_token_test.go
@@ -109,6 +109,9 @@ func TestModel_TokenFunctionality(t *testing.T) {
 		// Open the directory
 		model.state = model.state.SetOpen("/root/dir1", true)
 		
+		// Initialize the model to set up viewport
+		model.Init()
+		
 		// Get the view
 		view := model.View()
 		
@@ -158,6 +161,9 @@ func TestModel_TokenFunctionality(t *testing.T) {
 		assert.Equal(t, 0, model.tokenCount(dir1))
 		assert.Equal(t, 0, model.selectedTokens())
 		
+		// Initialize the model to set up viewport
+		model.Init()
+		
 		// View should still work
 		view := model.View()
 		assert.Contains(t, view, "(0)") // All files show 0 tokens
@@ -198,6 +204,9 @@ func TestModel_TokensWithLargeNumbers(t *testing.T) {
 	ignores := make(map[string]struct{})
 	model := NewModel(tree, &ignores)
 	model.SetTokens(tokens)
+	
+	// Initialize the model to set up viewport
+	model.Init()
 	
 	view := model.View()
 	


### PR DESCRIPTION
Previously, resizing the terminal would cause duplicate file entries to appear in the tree view. This was due to the manual viewport management logic trying to both build the tree AND crop it at the same time, leading to incorrect calculations when the terminal size changed.

The fix separates these concerns:
- Use bubble tea's viewport.Model to handle all scrolling/cropping
- buildTreeItems now always renders the complete tree
- The viewport handles what portion is visible on screen

This ensures each file path is rendered exactly once, eliminating duplicates.

🤖 Generated with [Claude Code](https://claude.ai/code)