### PR TITLE
Allow running picky without arguments and improve root display

### DIFF
--- a/cmd/picky/main.go
+++ b/cmd/picky/main.go
@@ -15,8 +15,16 @@ func main() {
 	flag.Parse()
 	
 	args := flag.Args()
-	if len(args) < 1 {
-		fmt.Fprintln(os.Stderr, "Usage: picky [options] <directory>")
+	
+	// Default to current directory if no argument provided
+	rootPath := "."
+	if len(args) > 0 {
+		rootPath = args[0]
+	}
+	
+	// Show help if requested
+	if len(args) > 1 {
+		fmt.Fprintln(os.Stderr, "Usage: picky [options] [directory]")
 		fmt.Fprintln(os.Stderr, "Options:")
 		flag.PrintDefaults()
 		fmt.Fprintln(os.Stderr, "\nInteractive controls:")
@@ -30,8 +38,6 @@ func main() {
 		fmt.Fprintln(os.Stderr, "\nExcluded paths are saved to .pickyignore in the target directory.")
 		os.Exit(1)
 	}
-	
-	rootPath := args[0]
 	
 	// Create app with OS filesystem
 	application := &app.App{

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -20,6 +20,13 @@ type App struct {
 
 // Run executes the application
 func (a *App) Run(rootPath string) error {
+	// Convert to absolute path to ensure proper name resolution
+	absPath, err := filepath.Abs(rootPath)
+	if err != nil {
+		return fmt.Errorf("resolve path: %w", err)
+	}
+	rootPath = absPath
+	
 	// Load existing ignores
 	ignores, err := ignore.Load(a.FS, rootPath)
 	if err != nil {

--- a/internal/app/app_root_name_test.go
+++ b/internal/app/app_root_name_test.go
@@ -1,0 +1,50 @@
+package app_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	
+	"github.com/eliooooooot/picky/internal/app"
+	"github.com/eliooooooot/picky/internal/fs"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAppRunResolvesRelativePaths(t *testing.T) {
+	// This test verifies that relative paths like "." are resolved to absolute paths
+	// We can't easily test the actual TUI, but we can verify the tree building works
+	
+	// Create a temporary directory for testing
+	tempDir, err := os.MkdirTemp("", "picky-test-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+	
+	// Create some test files
+	require.NoError(t, os.MkdirAll(filepath.Join(tempDir, "src"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(tempDir, "src", "main.go"), []byte("package main"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(tempDir, "README.md"), []byte("# Test"), 0644))
+	
+	// Change to the temp directory to test "."
+	originalWd, err := os.Getwd()
+	require.NoError(t, err)
+	defer os.Chdir(originalWd)
+	
+	require.NoError(t, os.Chdir(tempDir))
+	
+	// Create app
+	testApp := &app.App{
+		FS:         fs.NewOSFileSystem(),
+		OutputPath: "test-output.txt",
+	}
+	
+	// Test with "." - should work without error
+	// Note: We can't fully test the TUI part, but BuildTree should work
+	// The actual Run method will fail because we can't test the TUI
+	// So we'll just verify that the path resolution doesn't error
+	err = testApp.Run(".")
+	// We expect an error from the TUI, but not from path resolution
+	// If path resolution failed, we'd get "resolve path: ..." error
+	if err != nil {
+		require.NotContains(t, err.Error(), "resolve path:")
+	}
+}

--- a/internal/domain/tree_builder_test.go
+++ b/internal/domain/tree_builder_test.go
@@ -1,0 +1,80 @@
+package domain_test
+
+import (
+	"path/filepath"
+	"testing"
+	
+	"github.com/eliooooooot/picky/internal/domain"
+	"github.com/eliooooooot/picky/internal/fs"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildTreeRootName(t *testing.T) {
+	tests := []struct {
+		name         string
+		rootPath     string
+		expectedName string
+	}{
+		{
+			name:         "absolute path shows directory name",
+			rootPath:     "/Users/test/projects/myapp",
+			expectedName: "myapp",
+		},
+		{
+			name:         "nested path",
+			rootPath:     "/home/user/work",
+			expectedName: "work",
+		},
+		{
+			name:         "single level path",
+			rootPath:     "/projects",
+			expectedName: "projects",
+		},
+	}
+	
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a memory filesystem with a simple structure
+			memFS := fs.NewMemFileSystem()
+			require.NoError(t, memFS.MkdirAll(tt.rootPath, 0755))
+			
+			// Build tree
+			tree, err := domain.BuildTree(memFS, tt.rootPath)
+			require.NoError(t, err)
+			require.NotNil(t, tree)
+			require.NotNil(t, tree.Root)
+			
+			// Check root name
+			require.Equal(t, tt.expectedName, tree.Root.Name)
+		})
+	}
+}
+
+func TestBuildTreeRootFilesystem(t *testing.T) {
+	// Special test for root filesystem
+	// For memfs, we can't actually create "/" as it normalizes paths
+	// But we can test that filepath.Base("/") returns "/"
+	require.Equal(t, "/", filepath.Base("/"))
+}
+
+func TestBuildTreePreservesPath(t *testing.T) {
+	// Test that the full path is preserved even though name is just the base
+	memFS := fs.NewMemFileSystem()
+	rootPath := "/Users/test/projects/myapp"
+	require.NoError(t, memFS.MkdirAll(rootPath, 0755))
+	require.NoError(t, memFS.MkdirAll(filepath.Join(rootPath, "src"), 0755))
+	require.NoError(t, memFS.WriteFile(filepath.Join(rootPath, "src", "main.go"), []byte("package main"), 0644))
+	
+	tree, err := domain.BuildTree(memFS, rootPath)
+	require.NoError(t, err)
+	
+	// Root should have the base name but full path
+	require.Equal(t, "myapp", tree.Root.Name)
+	require.Equal(t, rootPath, tree.Root.Path)
+	
+	// Children should also have correct paths
+	require.Len(t, tree.Root.Children, 1)
+	srcDir := tree.Root.Children[0]
+	require.Equal(t, "src", srcDir.Name)
+	require.Equal(t, filepath.Join(rootPath, "src"), srcDir.Path)
+}


### PR DESCRIPTION
- Default to current directory when no argument provided
- Convert relative paths to absolute to ensure proper name resolution
- Root node now shows actual folder name instead of "." or ".."
- Added tests to verify root name behavior

🤖 Generated with [Claude Code](https://claude.ai/code)